### PR TITLE
Force str() to os and open calls for Windows

### DIFF
--- a/phy/apps/template/gui.py
+++ b/phy/apps/template/gui.py
@@ -86,7 +86,7 @@ class TemplateController(object):
             self.model = TemplateModel(dat_path, **kwargs)
         else:
             self.model = model
-        self.cache_dir = op.join(self.model.dir_path, '.phy')
+        self.cache_dir = op.join(str(self.model.dir_path), '.phy')
         self.context = Context(self.cache_dir)
         self.config_dir = config_dir
         self.view_creator = {

--- a/phy/plot/gloo/parser.py
+++ b/phy/plot/gloo/parser.py
@@ -60,7 +60,7 @@ def merge_includes(code):
                 log.critical('"%s" not found' % filename)
                 raise RuntimeError("File not found")
             text = '\n// --- start of "%s" ---\n' % filename
-            with open(path) as f:
+            with open(str(path)) as f:
                 text += remove_comments(f.read())
             text += '// --- end of "%s" ---\n' % filename
             return text

--- a/phy/plot/gloo/shader.py
+++ b/phy/plot/gloo/shader.py
@@ -96,11 +96,11 @@ class Shader(GLObject):
         self._version = version
 
         if os.path.isfile(code):
-            with open(code, 'rt') as file:
+            with open(str(code), 'rt') as file:
                 self._code = preprocess(file.read())
                 self._source = os.path.basename(code)
         else:
-            self._code = preprocess(code)
+            self._code = preprocess(str(code))
             self._source = '<string>'
 
         self._hooked = self._code

--- a/phy/plot/visuals.py
+++ b/phy/plot/visuals.py
@@ -572,9 +572,9 @@ class TextVisual(BaseVisual):
         font_size = 16 if not _is_high_dpi() else 32
         # The font texture is gzipped.
         fn = '%s-%d.npy.gz' % (font_name, font_size)
-        with gzip.open(curdir / 'static' / fn, 'rb') as f:
+        with gzip.open(str(curdir / 'static' / fn), 'rb') as f:
             self._tex = np.load(f)
-        with open(curdir / 'static' / 'chars.txt', 'r') as f:
+        with open(str(curdir / 'static' / 'chars.txt'), 'r') as f:
             self._chars = f.read()
 
     def _get_glyph_indices(self, s):

--- a/phy/utils/context.py
+++ b/phy/utils/context.py
@@ -44,7 +44,7 @@ class Context(object):
         self.cache_dir = Path(cache_dir).expanduser()
         if not self.cache_dir.exists():
             logger.debug("Create cache directory `%s`.", self.cache_dir)
-            os.makedirs(self.cache_dir)
+            os.makedirs(str(self.cache_dir))
 
         # Ensure the memcache directory exists.
         path = self.cache_dir / 'memcache'
@@ -87,7 +87,7 @@ class Context(object):
         path = self.cache_dir / 'memcache' / (name + '.pkl')
         if path.exists():
             logger.debug("Load memcache for `%s`.", name)
-            with open(path, 'rb') as fd:
+            with open(str(path), 'rb') as fd:
                 cache = load(fd)
         else:
             cache = {}
@@ -98,7 +98,7 @@ class Context(object):
         for name, cache in self._memcache.items():
             path = self.cache_dir / 'memcache' / (name + '.pkl')
             logger.debug("Save memcache for `%s`.", name)
-            with open(path, 'wb') as fd:
+            with open(str(path), 'wb') as fd:
                 dump(cache, fd)
 
     def memcache(self, f):


### PR DESCRIPTION
`WindowsPath` raise errors in windows when `os` calls are performed. Instead they work for `PosixPath`.
Running the newest phy version I hade to make these changes to make it run.