### PR TITLE
Fix rare error on undo

### DIFF
--- a/phy/cluster/supervisor.py
+++ b/phy/cluster/supervisor.py
@@ -204,6 +204,7 @@ class TaskLogger(object):
         assert name
         logger.log(
             5, "Log %s %s %s %s (%s)", sender.__class__.__name__, name, args, kwargs, output)
+        args = [a.tolist() if isinstance(a, np.ndarray) else a for a in args]
         task = (sender, name, args, kwargs, output)
         # Avoid successive duplicates (even if sender is different).
         if not self._history or self._history[-1][1:] != task[1:]:


### PR DESCRIPTION
Reverting a split with 'undo' results in an error if there is another split in the history with the same number of spike IDs. (Granted, that doesn't happen very often.)

```bash
11:08:24.429 [W] actions:213          Error when executing action Undo.
11:08:24.430 [D] actions:214          Traceback (most recent call last):
  File "/xxxxxxx/phy/gui/actions.py", line 211, in wrapped
    return callback(*args)
  File "/xxxxxxx/phylib/utils/event.py", line 141, in emit
    res.append(f(sender, *args, **kwargs))
  File "/xxxxxxx/phy/cluster/supervisor.py", line 851, in _on_action
    self.task_logger.process()
  File "/xxxxxxx/phy/cluster/supervisor.py", line 127, in process
    self._eval(task)
  File "/xxxxxxx/phy/cluster/supervisor.py", line 116, in _eval
    f(*args, **kwargs)
  File "/xxxxxxx/phy/cluster/supervisor.py", line 1136, in undo
    self._global_history.undo()
  File "/xxxxxxx/phy/cluster/_history.py", line 156, in undo
    for controller in controllers])
  File "/xxxxxxx/phy/cluster/_history.py", line 156, in <listcomp>
    for controller in controllers])
  File "/xxxxxxx/phy/cluster/clustering.py", line 485, in undo
    emit('cluster', self, up)
  File "/xxxxxxx/phylib/utils/event.py", line 141, in emit
    res.append(f(sender, *args, **kwargs))
  File "/xxxxxxx/phy/cluster/supervisor.py", line 673, in on_cluster
    emit('cluster', self, up)
  File "/xxxxxxx/phylib/utils/event.py", line 141, in emit
    res.append(f(sender, *args, **kwargs))
  File "/xxxxxxx/phy/cluster/supervisor.py", line 114, in _cluster_callback
    self._callback(task, up)
  File "/xxxxxxx/phy/cluster/supervisor.py", line 97, in _callback
    self.enqueue_after(task, output)
  File "/xxxxxxx/phy/cluster/supervisor.py", line 133, in enqueue_after
    getattr(self, '_after_%s' % name, f)(task, output)
  File "/xxxxxxx/phy/cluster/supervisor.py", line 184, in _after_undo
    self._select_state(self.last_state(last_action))
  File "/xxxxxxx/phy/cluster/supervisor.py", line 230, in last_state
    i = self._history.index(task)
ValueError: The truth value of an array with more than one element is ambiguous. Use a.any() or a.all()
```

In the `TaskLogger` tasks like 'select' have their arguments as simple Python lists. The task 'split' keeps them as numpy arrays, however (i.e. the spike IDs). If multiple splits with the same number of spike IDs are present in the `TaskLogger._history`, the check for equality in `self._history.index(task)` fails. Since the numpy arrays are of same length, numpy assumes an element-wise comparison.

It is difficult to provide a reproducible example, so here is some Python code to illustrate the problem:
```python
import numpy as np

# Tuples of similar layout as the tasks handled in the TaskLogger object
#         sender, name,  args,                  kwargs, output
task_a = (None, 'split', (np.array([1, 2, 3])), {}, None)
task_b = (None, 'split', (np.array([4, 5, 6])), {}, None)

# Test for equality
a == b
```
This produces the error:
```
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
ValueError: The truth value of an array with more than one element is ambiguous. Use a.any() or a.all()
```

If the numpy arrays were Python lists instead, this error does not occur.
```python
# Tuples of similar layout as the tasks handled in the TaskLogger object
#         sender, name,  args,        kwargs, output
task_a = (None, 'split', ([1, 2, 3]), {}, None)
task_b = (None, 'split', ([4, 5, 6]), {}, None)

# Test for equality
a == b
```
This returns `False` as expected.


The PR is quite simple and converts the numpy arrays into lists when adding them to the `TaskLogger._history`.

I am not sure if this is the best way to fix the issue.
