### PR TITLE
Added sticky headers to clusterView & similarityView tables

### DIFF
--- a/phy/gui/static/styles.css
+++ b/phy/gui/static/styles.css
@@ -51,6 +51,10 @@ th.sort { cursor: pointer; }
 }
 
 #table th {
+    position: -webkit-sticky;
+    position: sticky;
+    top: -0px;  /* 0px if you don't have a navbar, but something is required */
+    background: black;
     padding: 5px 5px 5px 5px;
 }
 

--- a/phy/gui/widgets.py
+++ b/phy/gui/widgets.py
@@ -409,23 +409,6 @@ class Table(HTMLWidget):
         b = self.builder
         b.set_body_src('index.html')
 
-        if is_high_dpi():  # pragma: no cover
-            b.add_style('''
-
-                /* This is for high-dpi displays. */
-                body {
-                    transform: scale(2);
-                    transform-origin: 0 0;
-                    overflow-y: scroll;
-                    /*overflow-x: hidden;*/
-                }
-
-                input.filter {
-                    width: 50% !important;
-                }
-
-            ''')
-
         b.add_style(_color_styles())
 
         self.data = data

--- a/phy/gui/widgets.py
+++ b/phy/gui/widgets.py
@@ -17,7 +17,7 @@ from qtconsole.inprocess import QtInProcessKernelManager
 from .qt import (
     WebView, QObject, QWebChannel, QWidget, QGridLayout, QPlainTextEdit,
     QLabel, QLineEdit, QCheckBox, QSpinBox, QDoubleSpinBox,
-    pyqtSlot, _static_abs_path, _block, is_high_dpi, Debouncer)
+    pyqtSlot, _static_abs_path, _block, Debouncer)
 from phylib.utils import emit, connect
 from phy.utils.color import colormaps, _is_bright
 from phylib.utils._misc import _CustomEncoder, read_text, _pretty_floats


### PR DESCRIPTION
table headers disappeared when scrolling in clusterView
Added sticky css position to table th
Had to remove high-dpi transformations in widgets.py because interfered with 'stickiness' property; trade-off necessitates setting a larger font-size with plugin.