### PR TITLE
updated environment.yml so people can also install env with that

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -5,6 +5,7 @@ channels:
 dependencies:
   - python
   - pip
+  - git
   - numpy
   - matplotlib
   - scipy

--- a/environment.yml
+++ b/environment.yml
@@ -3,7 +3,7 @@ channels:
   - conda-forge
   - defaults
 dependencies:
-  - python=3.7
+  - python
   - pip
   - numpy
   - matplotlib

--- a/environment.yml
+++ b/environment.yml
@@ -1,4 +1,7 @@
 name: phy2
+channels:
+  - conda-forge
+  - defaults
 dependencies:
   - python=3.7
   - pip
@@ -7,9 +10,18 @@ dependencies:
   - scipy
   - h5py
   - pyqt
+  - pyopengl
+  - pyqtwebengine
+  - pytest
+  - qtconsole
+  - requests
+  - responses
+  - traitlets
   - dask
   - cython
   - pillow
-  - sklearn
+  - scikit-learn
+  - joblib
   - pip:
-    - phy
+    - git+https://github.com/cortex-lab/phy.git
+


### PR DESCRIPTION
@rossant Welcome back!

I saw in the issues that some people were using the `environment.yml` file for install, so people don't use the yaml file with wrong versions I updated that.

In short I added all the dependencies you listed. Fixed the sklearn->scikit-learn and had it pull from git instead of pypi.

I just tested creating a conda env with 
`conda env create --file environment.yml`
and it worked fine on my computer.