### PR TITLE
Fix removal of imp in python 3.12

### DIFF
--- a/phy/utils/plugin.py
+++ b/phy/utils/plugin.py
@@ -11,7 +11,7 @@ Code from http://eli.thegreenplace.net/2012/08/07/fundamental-concepts-of-plugin
 # Imports
 #------------------------------------------------------------------------------
 
-import imp
+import importlib
 import logging
 import os
 from pathlib import Path
@@ -101,12 +101,12 @@ def discover_plugins(dirs):
         modname = path.stem
         if modname in ('phy_config', 'phycontrib_loader'):
             continue
-        file, path, descr = imp.find_module(modname, [subdir])
+        file, path, descr = importlib.util.find_spec(modname, [subdir])
         if file:
             # Loading the module registers the plugin in
             # IPluginRegistry.
             try:
-                mod = imp.load_module(modname, file, path, descr)  # noqa
+                mod = importlib.load_module(modname, file, path, descr)  # noqa
             except Exception as e:  # pragma: no cover
                 logger.exception(e)
             finally:


### PR DESCRIPTION
@rossant,

I don't actually have the phy test suite setup so I made this fix based on reading python docs. In Python 3.12 they have completely removed `imp` and the rec is to switch to `importlib`. Could you either test to make sure these changes work or walk me through setting up the phy test suite so I can make sure this works. 

If you don't want to do this I'll do a PR to change the python version to < 3.11 for the install stuff.