### PR TITLE
Set joblib requirement to install version less than 1.5.0. Resolves #1340.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ pyopengl==3.1.6
 requests
 qtconsole
 tqdm
-joblib
+joblib<1.5.0
 click
 mkdocs
 PyQtWebEngine


### PR DESCRIPTION
This enforces joblib<1.5.0 in requirements.txt, which fixes the issue noted in #1340. 