### PR TITLE
Fixing joblib version

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -22,7 +22,7 @@ dependencies:
   - cython
   - pillow
   - scikit-learn
-  - joblib
+  - joblib=1.4.2
   - pip:
     - git+https://github.com/cortex-lab/phy.git
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ pyopengl==3.1.6
 requests
 qtconsole
 tqdm
-joblib
+joblib=1.4.2
 click
 mkdocs
 PyQtWebEngine


### PR DESCRIPTION
Between version 1.4.2 and 1.5.0 joblib removed the bytes-limit keyword, as mentioned in [issue 1348](https://github.com/cortex-lab/phy/issues/1348).

As a hotfix it is frozen in the environment and the requirements.