### PR TITLE
Fix blank numpy-typed columns in native Qt ClusterView (#1377)

### DIFF
--- a/phy/gui/widgets.py
+++ b/phy/gui/widgets.py
@@ -358,7 +358,13 @@ class _TableModel(QAbstractTableModel):
         value = row.get(column)
 
         if role in (Qt.DisplayRole, Qt.EditRole):
-            return '' if value is None else value
+            if value is None:
+                return ''
+            # Qt's model/view cannot display numpy scalars (np.int64/np.float64),
+            # which render as blank cells; convert them to native Python types.
+            if hasattr(value, 'item'):
+                value = value.item()
+            return value
         if role == Qt.BackgroundRole and column == 'id':
             color = self._table._selection_background(row.get('id'))
             if color is not None:


### PR DESCRIPTION
phy 2.1.0rc1's rewritten native-Qt ClusterView (release-2.1) renders the numpy-typed columns (id / sh / depth / amp) as BLANK cells, while the native-Python columns (ch / fr / n_spikes / Amplitude) display fine.

Cause: `_TableModel.data()` returns numpy scalars (np.int64 / np.float64) to Qt's model/view, which cannot display them and shows empty cells.

Fix: convert numpy scalars to native Python via `.item()` in `data()`. The `hasattr(value, 'item')` guard means native-Python values (which lack `.item()`) pass through unchanged, so only the affected numpy columns are touched.

Tested on phy 2.1.0rc1 with a KiloSort4 sort: id/sh/depth/amp now display correctly and the previously-working columns are unaffected.

Fixes #1377.