### PR TITLE
Document phy 2.1.0 post-release steps

### DIFF
--- a/docs/announcement_2.1.0.md
+++ b/docs/announcement_2.1.0.md
@@ -27,6 +27,9 @@ Thank you to everyone who tested the release candidate and reported issues.
 Release notes and compatibility notes:
 https://phy.readthedocs.io/en/latest/release/
 
+GitHub release:
+https://github.com/cortex-lab/phy/releases/tag/v2.1.0
+
 Please report issues here:
 https://github.com/cortex-lab/phy/issues
 ```
@@ -40,6 +43,15 @@ This maintenance release of the current 2.x line focuses on fixing several long-
 
 The goal of this release is not to add major new features, but to make phy easier to install and more reliable again on current systems.
 
+Highlights include modernized packaging and CI, a native Qt ClusterView replacing the legacy web-based implementation, and improved GUI reliability across Linux, macOS, and Windows.
+
+Install or upgrade with:
+
+    python -m pip install --upgrade "phy==2.1.0"
+
 For release notes and compatibility notes, see:
 https://phy.readthedocs.io/en/latest/release/
+
+PyPI:
+https://pypi.org/project/phy/2.1.0/
 ```

--- a/docs/release.md
+++ b/docs/release.md
@@ -4,7 +4,15 @@ Current version is phy v2.1.0 (17 Jul 2026).
 
 ## phy 2.1.0 (17 Jul 2026)
 
-This final release incorporates the fixes identified during the `2.1.0rc1` testing period.
+This maintenance release makes phy easier to install and more reliable on current systems. It
+also incorporates the fixes identified during the `2.1.0rc1` testing period.
+
+### Highlights
+
+* Modernized dependencies, packaging, and continuous integration for Python 3.10 and newer.
+* Replaced the fragile legacy web-based ClusterView with a native Qt implementation.
+* Improved GUI startup, rendering, and resource cleanup across Linux, macOS, and Windows.
+* Kept dataset and file formats unchanged.
 
 ### Added
 
@@ -15,8 +23,34 @@ This final release incorporates the fixes identified during the `2.1.0rc1` testi
 * Preserve the ClusterView sort order when cluster metadata changes ([#1375](https://github.com/cortex-lab/phy/issues/1375)).
 * Display NumPy-typed values correctly in native Qt ClusterView columns ([#1377](https://github.com/cortex-lab/phy/issues/1377)).
 
+### Install or upgrade
 
-## phy 2.1.0rc1
+Use a fresh Python 3.10+ environment when possible, then install the exact stable release:
+
+```bash
+python -m pip install --upgrade pip
+python -m pip install --upgrade "phy==2.1.0"
+phy --version
+```
+
+The release is available from [PyPI](https://pypi.org/project/phy/2.1.0/) and its tagged source,
+release notes, and verified distribution files are available from the
+[GitHub release](https://github.com/cortex-lab/phy/releases/tag/v2.1.0).
+
+### Compatibility notes
+
+Dataset formats are unchanged. Plugins using supported Python-side controller, event, or view
+APIs are expected to keep working, but plugins that depend on internal HTML or other legacy
+web-based GUI components may require updates.
+
+Please report regressions on the [GitHub issue tracker](https://github.com/cortex-lab/phy/issues)
+and include the operating system, Python version, installation method, and whether plugins are
+enabled.
+
+## Historical release candidate: phy 2.1.0rc1
+
+The material in this section records the release-candidate testing instructions and is retained
+for reference. New installations should use the final `2.1.0` release above.
 
 With substantial help from AI-assisted development, it has been possible to put time and effort
 into this maintenance release for the current 2.x line.
@@ -97,7 +131,8 @@ working unchanged, but they should still be tested.
 
 ### Testing window
 
-Testing for `2.1.0rc1` is expected to stay open for at least the next couple of months before a final `2.1.0` release.
+The `2.1.0rc1` testing window remained open before the final `2.1.0` release and provided the
+feedback used for the fixes listed above.
 
 ### Feedback
 

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -154,3 +154,22 @@ fall back to:
 make smoke-test SMOKE_VERSION=<version>
 make open-test SMOKE_VERSION=<version>
 ```
+
+## Post-release checklist
+
+After the final PyPI upload succeeds:
+
+1. Confirm the PyPI JSON index lists both the wheel and source distribution, and verify their
+   SHA-256 hashes against the files built from the release tag.
+2. Install the exact version from PyPI in a fresh environment with `make smoke-pypi
+   SMOKE_VERSION=<version>` and complete the GUI check with `make open-pypi
+   SMOKE_VERSION=<version>`.
+3. Create a non-prerelease GitHub release from the existing annotated tag. Attach the exact wheel
+   and source distribution already verified against PyPI; do not rebuild them.
+4. Verify the documentation build for the default branch and check the live release notes,
+   README badges, PyPI page, and GitHub release links.
+5. Publish the prepared community announcement only after PyPI, GitHub, and the documentation are
+   live.
+6. Close or update the release milestone. Keep the release branch until all public artifacts have
+   been checked, then remove it only with maintainer approval.
+7. Make any development-version bump on the default branch in a separate pull request.


### PR DESCRIPTION
## Summary

- expand the final 2.1.0 release notes with highlights, stable installation, and compatibility guidance
- mark the 2.1.0rc1 material as historical
- add a reusable post-release maintainer checklist
- finalize the GitHub and community announcement links

## Why

The final package is live on PyPI, but the public documentation and maintainer workflow need to clearly distinguish the stable release from the historical release candidate and document the remaining publication checks.

## Validation

- `uv run --group dev mkdocs build --strict`
- `git diff --check`

The strict documentation build completed successfully. It reported only existing tutorial-link and navigation notices.