### PR TITLE
Fix Read the Docs dependency setup

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -7,7 +7,3 @@ build:
 
 mkdocs:
   configuration: mkdocs.yml
-
-python:
-  install:
-    - requirements: requirements.txt


### PR DESCRIPTION
## Summary

- remove the stale `requirements.txt` installation from the Read the Docs configuration
- rely on the native MkDocs environment prepared by Read the Docs

## Root cause

The root `requirements.txt` was removed during the uv migration, but `.readthedocs.yaml` still instructed Read the Docs to install it. Build 33633688 therefore stopped before the MkDocs build.

## Impact

The `latest` documentation can build from `master` again and publish the final phy 2.1.0 release notes.

## Validation

- parsed `.readthedocs.yaml` and verified the MkDocs configuration
- `uv run mkdocs build --strict`
- `git diff --check`