### PR TITLE
Start 2.1.1 development

### DIFF
--- a/phy/__init__.py
+++ b/phy/__init__.py
@@ -27,7 +27,7 @@ from .utils.plugin import IPlugin, get_plugin, discover_plugins
 
 __author__ = 'Cyrille Rossant'
 __email__ = 'cyrille.rossant at gmail.com'
-__version__ = '2.1.0'
+__version__ = '2.1.1.dev0'
 __version_git__ = __version__ + _git_version()
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "phy"
-version = "2.1.0" # No dynamic lookup needed
+version = "2.1.1.dev0" # No dynamic lookup needed
 description = "Interactive visualization and manual spike sorting of large-scale ephys data"
 readme = "README.md"
 license = "BSD-3-Clause"

--- a/uv.lock
+++ b/uv.lock
@@ -1389,7 +1389,7 @@ wheels = [
 
 [[package]]
 name = "phy"
-version = "2.1.0"
+version = "2.1.1.dev0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

- advance the repository development version from `2.1.0` to `2.1.1.dev0`
- keep `pyproject.toml`, `phy.__version__`, and the editable package entry in `uv.lock` synchronized
- leave the README and documentation on `2.1.0`, which remains the current stable release

## Why

Development builds from `master` should no longer identify themselves as the immutable `2.1.0` release. The `.dev0` version also ensures the production publish helper refuses an accidental upload.

## Validation

- version consistency check across all three files
- `uv lock --check`
- `uv run --frozen phy --version`
- `uv run --frozen pytest -q phy/utils/tests/test_plugin.py`
- `uv build` and package metadata inspection
- `git diff --check`