### PR TITLE
Fix display of multi-valued cluster metadata

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -8,7 +8,7 @@ This file records user-visible changes to phy. The format is based on
 
 Changes below are available from the latest source checkout but have not yet
 been included in a stable release. The current entries cover all user-visible
-changes committed on 23–24 July 2026; test-only commits are represented by the
+changes committed since 23 July 2026; test-only commits are represented by the
 behavior they verify rather than listed separately.
 
 ### Added
@@ -48,6 +48,8 @@ behavior they verify rather than listed separately.
 - Cluster and Similarity View filters only take keyboard focus after an
   explicit click, including when a table is first shown or refreshed. Enter,
   Escape, and outside clicks release filter focus so global shortcuts resume.
+- Display metadata columns containing multiple values in the Cluster and
+  Similarity Views instead of leaving their cells blank.
 
 ### Changed
 

--- a/phy/cluster/tests/test_supervisor.py
+++ b/phy/cluster/tests/test_supervisor.py
@@ -242,6 +242,18 @@ def test_cluster_view_formats_spike_counts(qtbot, gui):
     assert index.data(Qt.EditRole) == 1234567
 
 
+def test_cluster_view_formats_multiple_values(qtbot, gui):
+    cv = ClusterView(
+        gui,
+        data=[{'id': 1, 'n_spikes': 10, 'tags': ['tag_a', 'tag_b']}],
+        columns=['tags'],
+    )
+    _wait_until_table_ready(qtbot, cv)
+
+    index = cv._proxy.index(0, cv.columns.index('tags'))
+    assert index.data(Qt.DisplayRole) == 'tag_a, tag_b'
+
+
 def test_similarity_view_1(qtbot, gui):
     sv = SimilarityView(gui)
     _wait_until_table_ready(qtbot, sv)

--- a/phy/gui/widgets.py
+++ b/phy/gui/widgets.py
@@ -14,6 +14,7 @@ import sys
 from contextlib import contextmanager
 from functools import partial
 
+import numpy as np
 from phylib.utils import connect, emit
 from phylib.utils._misc import _CustomEncoder, _pretty_floats
 from phylib.utils._types import _is_integer
@@ -364,8 +365,13 @@ class _TableModel(QAbstractTableModel):
                 return ''
             # Qt's model/view cannot display numpy scalars (np.int64/np.float64),
             # which render as blank cells; convert them to native Python types.
-            if hasattr(value, 'item'):
+            if isinstance(value, np.generic):
                 value = value.item()
+            if role == Qt.DisplayRole:
+                if isinstance(value, np.ndarray):
+                    value = value.tolist()
+                if isinstance(value, (list, tuple)):
+                    return ', '.join(map(str, value))
             # Keep the raw value available for sorting and filtering, while making
             # spike counts easier to scan in the cluster and similarity tables.
             if role == Qt.DisplayRole and column == 'n_spikes' and isinstance(value, int):


### PR DESCRIPTION
## Summary

- Display list-, tuple-, and NumPy-array-valued metadata as comma-separated text in native cluster tables.
- Preserve native NumPy scalar conversion.
- Add a focused ClusterView regression test and changelog entry.

## Root cause

The Qt table model returned collection values directly for Qt DisplayRole. Qt renders those unsupported values as empty cells, unlike the previous web table.

## Validation

- 46 native table and focused ClusterView tests passed.
- make lint
- make format-check
- Documentation link check and strict MkDocs build

Fixes #1402.